### PR TITLE
Dockerize stack and add make workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `api-server/` hosts the Axum backend; request flow sits in `src/handlers`, `models`, `services`, and `middleware`, shared state in `lib.rs`, integration tests in `tests/`, and SQLx migrations in `migrations/`.
+- `BAM_UI/` houses the Vite + React app; reusable UI sits in `src/components`, shared logic in `src/hooks` and `src/context`, and domain contracts in `src/types`.
+
+## Build, Test, and Development Commands
+- Docker stack: `make` (or `make up`) builds images and starts Postgres, the API, and the frontend; stop everything with `make down` and reclaim space with `make prune`.
+- Backend: target Rust 1.82+ (see `rustup override set 1.82.0`); `cargo run` boots the API once `.env` is populated, and `DATABASE_URL=postgres://... sqlx migrate run` applies migrations.
+- Backend quality: run `cargo fmt` and `cargo clippy --all-targets --all-features` before pushing.
+- Frontend: inside `BAM_UI/` run `npm install`, then `npm run dev`, `npm run build`, and `npm run lint`.
+
+## Coding Style & Naming Conventions
+- Rust modules follow snake_case filenames and favour `Result<T, anyhow::Error>` with `thiserror` variants; document public handlers and keep them concise.
+- TypeScript uses 2-space indentation, strict mode, and PascalCase components; rely on the configured aliases (e.g. `@components/*`) instead of relative paths.
+- Keep Tailwind utility classes inline and lift recurring patterns into `src/lib` helpers instead of new CSS.
+
+## Testing Guidelines
+- Run `cargo test` for backend coverage and extend the async helpers in `api-server/tests/integration_tests.rs` instead of hitting real I/O or secrets.
+- When routes require auth, reuse the `create_auth_request` pattern to keep tokens isolated from assertions.
+- Frontend testing is not yet configured; at minimum run `npm run lint`, and add Vitest or React Testing Library coverage before merging major UI changes.
+
+## Commit & Pull Request Guidelines
+- Follow the local style: short, imperative summaries with optional scopes (e.g. `refactor(ui): split layout panels` or `calleum/21: update IA client wiring`) and reference issues when possible.
+- Squash WIP commits before opening a PR; describe the change, call out migrations or env vars, and highlight backend versus frontend impact.
+- Add UI screenshots or terminal captures when appropriate, and only request review after linting, formatting, and tests succeed locally.
+
+## Environment & Configuration Tips
+- Copy `.env.example` if present or set at least `DATABASE_URL`, `JWT_SECRET`, and the file storage paths required by `Config::from_env`; use `.env.local` for machine-specific overrides.
+- Enable the `uuid-ossp` extension in PostgreSQL before running migrations, and keep `uploads/` writable when testing the file-store service.

--- a/BAM_UI/.dockerignore
+++ b/BAM_UI/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.gitignore

--- a/BAM_UI/Dockerfile
+++ b/BAM_UI/Dockerfile
@@ -1,0 +1,20 @@
+# syntax = docker/dockerfile:1.6
+
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine AS runtime
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/BAM_UI/nginx.conf
+++ b/BAM_UI/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}

--- a/BAM_UI/src/components/booking/BookingList.tsx
+++ b/BAM_UI/src/components/booking/BookingList.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { Booking, Bioscope } from "@types";
 import { Button } from "@components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@components/ui/card";

--- a/BAM_UI/src/components/booking/BookingSchedule.tsx
+++ b/BAM_UI/src/components/booking/BookingSchedule.tsx
@@ -1,6 +1,5 @@
 // Student view: list of bookings for the selected date/bioscope, rendered with
 // status badges and requester details.
-import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@components/ui/card";
 import { Badge } from "@components/ui/badge";
 import { ShieldCheck } from "lucide-react";

--- a/BAM_UI/src/components/dashboard/AnalyticsDashboard.tsx
+++ b/BAM_UI/src/components/dashboard/AnalyticsDashboard.tsx
@@ -1,6 +1,5 @@
 // Admin view: aggregate analytics widgets (day utilization, demand by hour,
 // top requesters, utilization by bioscope) using recharts primitives.
-import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@components/ui/card";
 import { LineChart as LineChartIcon, BarChart3 } from "lucide-react";
 import {

--- a/BAM_UI/src/components/teacher/ApprovalQueue.tsx
+++ b/BAM_UI/src/components/teacher/ApprovalQueue.tsx
@@ -2,7 +2,6 @@
  * Teacher view: pending approvals list with conflict/fair-use hints.
  * Accepts the full bookings list to compute conflicts and requester stats.
  */
-import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@components/ui/card";
 import { Badge } from "@components/ui/badge";
 import { Button } from "@components/ui/button";

--- a/BAM_UI/src/components/teacher/DayAtAGlance.tsx
+++ b/BAM_UI/src/components/teacher/DayAtAGlance.tsx
@@ -1,6 +1,5 @@
 // Teacher view: compact timeline for a single day/bioscope showing whether
 // each slot is open or which booking occupies it.
-import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@components/ui/card";
 import { Clock } from "lucide-react";
 import type { Slot, Booking } from "@types";

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+COMPOSE ?= docker compose
+
+.PHONY: up down build logs ps clean prune
+
+# Bring up the entire stack (frontend, backend, database)
+up:
+	$(COMPOSE) up --build
+
+# Stop services and remove containers (keeps volumes)
+down:
+	$(COMPOSE) down
+
+# Build images without starting containers
+build:
+	$(COMPOSE) build
+
+# Tail service logs
+logs:
+	$(COMPOSE) logs -f
+
+# Show service status
+ps:
+	$(COMPOSE) ps
+
+# Remove containers, networks, and persistent volumes
+clean:
+	$(COMPOSE) down -v --remove-orphans
+
+# Stop services and prune Docker artifacts (containers, images, volumes, networks)
+prune:
+	$(COMPOSE) down -v --remove-orphans
+	docker system prune -af --volumes

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-This is a Readme
+# BAM Brazil Toolkit
+
+This repository contains the Bioscope Allocation & Management (BAM) tooling used in COMP4050. It is split into two subsystems:
+
+- `api-server/`: Rust (Axum + SQLx) backend providing booking, session, and IA integration endpoints.
+- `BAM_UI/`: React + Vite frontend that visualises bookings, approvals, and analytics.
+
+Both services are containerised and can be orchestrated together with Docker Compose and the provided `Makefile`.
+
+## Prerequisites
+
+- Docker 24+ (includes Docker Compose v2)
+- GNU Make
+- (Optional for local builds) Rust 1.82+ and Node 20+ if you prefer to run the services outside containers.
+
+## Quick Start with Docker
+
+1. Copy `.env.example` to `.env` (if present) and populate required secrets such as `DATABASE_URL`, `JWT_SECRET`, and file-storage paths.
+2. Run `make` (alias for `make up`) from the repository root:
+   - Builds the backend/ frontend images.
+   - Starts `db` (PostgreSQL), `api` (Axum server on `http://localhost:3000`), and `frontend` (Vite build served by Nginx on `http://localhost:5173`).
+3. Stop the stack with `make down` when you are done.
+
+## Useful Commands
+
+| Command | Description |
+| ------- | ----------- |
+| `make` / `make up` | Build images and start all services defined in `docker-compose.yml`. |
+| `make down` | Stop containers and remove default networks (volumes are kept). |
+| `make build` | Rebuild images without starting the stack. |
+| `make logs` | Tail logs from all services. |
+| `make ps` | Show container status. |
+| `make prune` | Stop the stack then run `docker system prune -af --volumes` to reclaim space. |
+
+> **Tip:** If you modify backend SQL queries or migrations, rebuild the `api` image with `docker compose build api` (or `make build`) so compile-time SQL checks run against the updated schema.
+
+## Local Development (Optional)
+
+If you prefer not to use Docker:
+
+- Backend: ensure PostgreSQL is running and execute `cargo run` from `api-server/`. Run migrations with `sqlx migrate run`.
+- Frontend: inside `BAM_UI/`, install dependencies (`npm install`) and start Vite with `npm run dev`.
+
+Refer to `AGENTS.md` for contributor guidelines, coding standards, and testing expectations.

--- a/api-server/.dockerignore
+++ b/api-server/.dockerignore
@@ -1,0 +1,4 @@
+target
+.git
+.gitignore
+README.md

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "bam"
 version = "0.1.0"
 edition = "2021"
 authors = ["calleum.pecqueux"]
+rust-version = "1.82"
 
 [dependencies]
 # Web framework
@@ -54,3 +55,4 @@ validator = { version = "0.20", features = ["derive"] }
 utoipa = { version = "5.4", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
 utoipa-axum = "0.2"
+base64ct = "=1.7.1"

--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -1,0 +1,49 @@
+# syntax = docker/dockerfile:1.6
+
+FROM rust:1.83 AS builder
+
+WORKDIR /app
+
+# Install build dependencies for sqlx (Postgres) and TLS
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev libpq-dev ca-certificates postgresql \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cache dependencies
+COPY Cargo.toml Cargo.lock* ./
+RUN mkdir src \
+    && echo 'fn main() { println!("placeholder"); }' > src/main.rs \
+    && cargo fetch \
+    && rm -rf src
+
+# Build application
+COPY . .
+ENV DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/bam
+RUN set -eux; \
+    for dir in /etc/postgresql/*; do version="$(basename "$dir")"; pg_ctlcluster "$version" main start; done; \
+    su - postgres -c "dropdb --if-exists bam"; \
+    su - postgres -c "createdb bam"; \
+    su - postgres -c "psql -v ON_ERROR_STOP=1 -c \"ALTER USER postgres WITH PASSWORD 'postgres';\""; \
+    for f in /app/migrations/*.sql; do \
+        su - postgres -c "psql -v ON_ERROR_STOP=1 -d bam -f \"$f\""; \
+    done; \
+    cargo build --release; \
+    for dir in /etc/postgresql/*; do version="$(basename "$dir")"; pg_ctlcluster "$version" main stop; done
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 libpq5 \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates
+
+WORKDIR /app
+
+# Copy binary
+COPY --from=builder /app/target/release/bam /app/bam
+
+ENV RUST_LOG=info
+
+EXPOSE 3000
+
+CMD ["./bam"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.9"
+
+services:
+  api:
+    build:
+      context: ./api-server
+      dockerfile: Dockerfile
+    environment:
+      BIND_ADDRESS: 0.0.0.0:3000
+      PORT: 3000
+      DATABASE_URL: postgres://postgres:postgres@db:5432/bam
+      JWT_SECRET: change-me-in-prod
+      FILE_STORAGE_PATH: /data/uploads
+      IA_BASE_URL: http://localhost:8080
+      IA_TIMEOUT: 30
+    volumes:
+      - uploads_data:/data/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+
+  frontend:
+    build:
+      context: ./BAM_UI
+      dockerfile: Dockerfile
+    depends_on:
+      - api
+    ports:
+      - "5173:80"
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: bam
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+volumes:
+  db_data:
+  uploads_data:


### PR DESCRIPTION
## Summary
- add Dockerfiles for the Rust API and Vite frontend plus compose orchestration
- introduce Make targets (`up`, `down`, `build`, `logs`, `ps`, `clean`, `prune`) and document usage in README/AGENTS
- update backend build pipeline to run SQLx migrations during image build with Rust 1.82+
- tidy React imports flagged by TypeScript and add contributor guidance on the new workflow
