### PR TITLE
Eleazar/apigaps

### DIFF
--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -40,6 +40,7 @@ use utoipa_swagger_ui::SwaggerUi;
         handlers::auth::login,
         handlers::auth::logout,
         handlers::auth::refresh_token,
+        handlers::auth::users_me,
         handlers::bookings::list_bookings,
         handlers::bookings::create_booking,
         handlers::bookings::get_booking,
@@ -119,6 +120,8 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/auth/login", post(handlers::auth::login))
         .route("/api/auth/logout", post(handlers::auth::logout))
         .route("/api/auth/refresh", post(handlers::auth::refresh_token))
+        //Identity
+        .route("/api/users/me", get(handlers::auth::users_me))
         // Booking routes (from existing UI)
         .route("/api/bookings", get(handlers::bookings::list_bookings))
         .route("/api/bookings", post(handlers::bookings::create_booking))

--- a/api-server/src/middleware/auth.rs
+++ b/api-server/src/middleware/auth.rs
@@ -47,7 +47,10 @@ pub async fn auth_middleware(
 
     // Validate and decode JWT token
     let claims = validate_jwt_token(&token, &state.config.auth.jwt_secret)
-        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+        .map_err(|_| {
+            tracing::warn!("Unauthorized: Invalid or expired token");
+            StatusCode::UNAUTHORIZED
+        })?;
 
     // Add user information to request extensions
     request.extensions_mut().insert(claims);


### PR DESCRIPTION
### 1. Identity Contract

- JWT sub used for identity contract. `sub` = `user_id` (UUID) when issuing tokens.

- Middleware decodes and parses `sub → claims.user_id` once in `validate_jwt_token`.

- `refresh_token` handler also re-parses sub for consistency.

- All handlers now use` claims.user_id` for DB lookups

### 2. New Endpoint – /api/users/me:

- GET /api/users/me implemented: Returns ApiResponse, or 404 "User not found for token subject" when the sub can’t be resolved.

### 3. 401 Message

- Invalid or expired tokens return 401 Unauthorized, with tracing::warn! logged for visibility in server logs